### PR TITLE
Added device name to iOS plugin

### DIFF
--- a/src/ios/CDVDevice.m
+++ b/src/ios/CDVDevice.m
@@ -109,7 +109,8 @@
              @"has3DTouch": @([self has3DTouch]),
              @"biometricType": [self getBiometryType],
 
-             @"accessibility": accessibility
+             @"accessibility": accessibility,
+             @"model": [device name],
              };
 }
 


### PR DESCRIPTION

As android doesn't offer this without requesting bluetooth permissions, only available on iOS.