### PR TITLE
[BG-I44373] Expose androidAutoSupported via gearhead companion-app detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-device",
-  "version": "1.1.3-dev",
+  "version": "1.1.4",
   "description": "Cordova Device Plugin",
   "cordova": {
     "id": "cordova-plugin-device",

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-device"
-    version="1.1.3-dev">
+    version="1.1.4">
     <name>Device</name>
     <description>Cordova Device Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -66,6 +66,12 @@
         <source-file src="src/android/Device.java" target-dir="src/org/apache/cordova/device" />
 
         <framework src="com.squareup:seismic:1.0.2" />
+
+        <config-file target="AndroidManifest.xml" parent="/manifest">
+            <queries>
+                <package android:name="com.google.android.projection.gearhead"/>
+            </queries>
+        </config-file>
     </platform>
 
     <!-- amazon-fireos -->

--- a/src/android/Device.java
+++ b/src/android/Device.java
@@ -73,6 +73,8 @@ public class Device extends CordovaPlugin implements ShakeDetector.Listener {
 
     private static boolean isTablet = false;
 
+    private static final String ANDROID_AUTO_PACKAGE = "com.google.android.projection.gearhead";
+
     private long lastShakeTimestamp = 0;
 
     /**
@@ -141,6 +143,7 @@ public class Device extends CordovaPlugin implements ShakeDetector.Listener {
 
             r.put("isTablet", isTablet);
             r.put("has3DTouch", false);
+            r.put("androidAutoSupported", isAndroidAutoSupported());
 
             JSONObject accessibility = new JSONObject();
             accessibility.put("textSizeAdjustment", 200);
@@ -298,5 +301,14 @@ public class Device extends CordovaPlugin implements ShakeDetector.Listener {
 
     private String getAppName() {
         return String.valueOf(cordova.getActivity().getTitle());
+    }
+
+    private boolean isAndroidAutoSupported() {
+        try {
+            cordova.getActivity().getPackageManager().getPackageInfo(ANDROID_AUTO_PACKAGE, 0);
+            return true;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
     }
 }

--- a/www/device.js
+++ b/www/device.js
@@ -81,6 +81,7 @@ function Device() {
             me.biometricType = info.biometricType || "unknown";
 
             me.accessibility = info.accessibility || { textSizeAdjustment: 100 };
+            me.androidAutoSupported = info.androidAutoSupported || false;
 
             channel.onCordovaInfoReady.fire();
         },function(e) {


### PR DESCRIPTION
Ticket: https://bugtracker.zoho.eu/portal/loxone#zp/projects/16571000000023018/issue-detail/16571000016234626

## Summary

Adds a runtime check for the Android Auto companion app
(`com.google.android.projection.gearhead`) and surfaces the result as
`androidAutoSupported` in the `getDeviceInfo` payload. Consumers can use
this to gate Android Auto-related UI without relying on tablet form-factor
heuristics.

## Motivation

Kerberos currently gates the Car Actions menu entry on the existing
`isTablet` flag, which on Android is derived from
`Configuration.screenLayout & SCREENLAYOUT_SIZE_MASK`. That bucket is
recomputed when the user adjusts the system Display Size slider, so a
borderline-sized phone can flip between phone-class and tablet-class
classification without any hardware change. The downstream effect is that
Android Auto silently disappears from the menu when users reduce their
Display Size.

The new flag answers the question we actually care about — "can this
device use Android Auto?" — directly. Gearhead is preinstalled on phones
in AA-supported markets, absent on tablets and on devices in markets
where AA is not shipped, and not affected by user accessibility settings.

## Changes

- `src/android/Device.java`
  - Adds `ANDROID_AUTO_PACKAGE` constant for the gearhead package name
  - Adds `isAndroidAutoSupported()` helper that probes the package via
    `PackageManager.getPackageInfo`
  - Exposes the result as `androidAutoSupported` in the JSON returned by
    the `getDeviceInfo` action

## Host-app requirements

For the package query to succeed on Android 11+ the host app's
`AndroidManifest.xml` must declare:

    <queries>
        <package android:name="com.google.android.projection.gearhead"/>
    </queries>

Without this declaration `getPackageInfo` will throw
`NameNotFoundException` even on devices where AA is installed, and the
flag will always be `false`. The companion Kerberos MR handles this in
`Loxone/config.xml`.
